### PR TITLE
Add guided Chemex brew widget to the active theme

### DIFF
--- a/public/wp-content/themes/chemex-club/chemex-brew.php
+++ b/public/wp-content/themes/chemex-club/chemex-brew.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Chemex Brew Widget
+ *
+ * Renders the floating "Brew Chemex" button and the step-by-step
+ * brewing wizard modal. Loaded globally from footer.php.
+ */
+?>
+<button type="button" class="chemex-brew-trigger" aria-label="Start a Chemex brew">
+    <i class="fas fa-coffee"></i>Brew Chemex
+</button>
+
+<div class="chemex-brew-overlay" role="dialog" aria-modal="true" aria-labelledby="chemex-brew-title">
+    <div class="chemex-brew-modal">
+        <button type="button" class="chemex-close" aria-label="Close">&times;</button>
+
+        <div class="chemex-brew-stage is-active" data-stage="setup">
+            <h2 id="chemex-brew-title">Brew a Chemex</h2>
+            <p class="chemex-subtitle">Pour-over coffee, guided step by step.</p>
+
+            <div class="chemex-cups-input">
+                <label for="chemex-cups">Cups</label>
+                <input type="number" id="chemex-cups" min="1" max="10" value="2" />
+                <span class="chemex-subtitle">~250ml each</span>
+            </div>
+
+            <div class="chemex-recipe">
+                You'll need <span class="chemex-recipe-coffee">30g</span> of medium-coarse coffee
+                and <span class="chemex-recipe-water">500ml</span> of water at 94–96&deg;C.
+            </div>
+
+            <div style="margin: 14px 0 22px;">
+                <label style="font-size: 0.9em; color: #573110; cursor: pointer;">
+                    <input type="checkbox" id="chemex-auto-advance" checked />
+                    Auto-advance when each step's timer ends
+                </label>
+            </div>
+
+            <div class="chemex-actions">
+                <span></span>
+                <div class="chemex-actions-right">
+                    <button type="button" class="chemex-btn chemex-start">Start brewing</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="chemex-brew-stage" data-stage="brewing">
+            <h2 id="chemex-brew-title-brewing">Brewing</h2>
+            <div class="chemex-progress"></div>
+
+            <div class="chemex-timers">
+                <div class="chemex-timer chemex-timer-universal">
+                    <div class="chemex-timer-label">Total</div>
+                    <div class="chemex-timer-value">00:00</div>
+                </div>
+                <div class="chemex-timer chemex-timer-step">
+                    <div class="chemex-timer-label">This step</div>
+                    <div class="chemex-timer-value">00:00</div>
+                </div>
+            </div>
+
+            <div class="chemex-step-card">
+                <div class="chemex-step-meta">Step 1</div>
+                <h3 class="chemex-step-title">&nbsp;</h3>
+                <p class="chemex-step-desc">&nbsp;</p>
+                <span class="chemex-pour"></span>
+            </div>
+
+            <div class="chemex-actions">
+                <button type="button" class="chemex-btn chemex-btn-ghost chemex-prev">Back</button>
+                <div class="chemex-actions-right">
+                    <button type="button" class="chemex-btn chemex-next">Next step</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="chemex-brew-stage" data-stage="done">
+            <div class="chemex-complete">
+                <i class="fas fa-mug-hot"></i>
+                <h3>Your Chemex is ready.</h3>
+                <p>Total brew time: <strong class="chemex-total-time">00:00</strong></p>
+                <button type="button" class="chemex-btn chemex-restart">Brew another</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/public/wp-content/themes/chemex-club/footer.php
+++ b/public/wp-content/themes/chemex-club/footer.php
@@ -2,4 +2,6 @@
     <i class="fas fa-coffee"></i> Brewed at <a href="https://coloredcow.com">ColoredCow</a>.
 </footer>
 
+<?php get_template_part('chemex-brew'); ?>
+
 </body>

--- a/public/wp-content/themes/chemex-club/src/js/chemex-brew.js
+++ b/public/wp-content/themes/chemex-club/src/js/chemex-brew.js
@@ -1,0 +1,324 @@
+(function () {
+    'use strict';
+
+    var COFFEE_RATIO_G_PER_CUP = 15;
+    var WATER_ML_PER_CUP = 250;
+    var BLOOM_RATIO = 2;
+
+    var state = {
+        cups: 2,
+        coffee: 0,
+        water: 0,
+        bloomWater: 0,
+        pour1Water: 0,
+        pour2Water: 0,
+        stepIndex: 0,
+        steps: [],
+        universalStart: null,
+        universalInterval: null,
+        stepInterval: null,
+        stepEndsAt: null,
+        autoAdvance: true
+    };
+
+    function pad(n) {
+        return n < 10 ? '0' + n : '' + n;
+    }
+
+    function formatTime(ms) {
+        if (ms < 0) ms = 0;
+        var total = Math.floor(ms / 1000);
+        var m = Math.floor(total / 60);
+        var s = total % 60;
+        return pad(m) + ':' + pad(s);
+    }
+
+    function buildRecipe(cups) {
+        var coffee = Math.round(cups * COFFEE_RATIO_G_PER_CUP);
+        var water = cups * WATER_ML_PER_CUP;
+        var bloomWater = coffee * BLOOM_RATIO;
+        var afterBloom = water - bloomWater;
+        var pour1Water = bloomWater + Math.round(afterBloom * 0.55);
+        var pour2Water = water;
+
+        return {
+            coffee: coffee,
+            water: water,
+            bloomWater: bloomWater,
+            pour1Water: pour1Water,
+            pour2Water: pour2Water
+        };
+    }
+
+    function buildSteps(recipe) {
+        return [
+            {
+                title: 'Rinse the filter',
+                meta: 'Prep',
+                duration: 30,
+                description: 'Place the filter in the Chemex with the triple-fold side against the spout. Rinse thoroughly with hot water to remove paper taste and pre-heat the glass. Discard the rinse water.',
+                pour: null
+            },
+            {
+                title: 'Add the grounds',
+                meta: 'Prep',
+                duration: 20,
+                description: 'Add ' + recipe.coffee + 'g of medium-coarse ground coffee. Give the Chemex a gentle shake to level the bed.',
+                pour: recipe.coffee + 'g coffee'
+            },
+            {
+                title: 'Bloom',
+                meta: 'Pour 1 of 3',
+                duration: 45,
+                description: 'Start your timer. Pour just enough water to saturate all the grounds — about 2x the coffee weight. Pour in a spiral from the center outward. Watch the bed puff up.',
+                pour: 'Pour to ' + recipe.bloomWater + 'g · wait 45s'
+            },
+            {
+                title: 'First main pour',
+                meta: 'Pour 2 of 3',
+                duration: 45,
+                description: 'Pour slowly in concentric circles, keeping the water level steady. Avoid pouring directly on the filter wall.',
+                pour: 'Pour to ' + recipe.pour1Water + 'g'
+            },
+            {
+                title: 'Final pour',
+                meta: 'Pour 3 of 3',
+                duration: 60,
+                description: 'Continue pouring in slow spirals until you reach the target weight. Aim to finish pouring by ~3:00.',
+                pour: 'Pour to ' + recipe.pour2Water + 'g'
+            },
+            {
+                title: 'Drawdown',
+                meta: 'Final',
+                duration: 90,
+                description: 'Let the water draw down completely. Total brew time should be around 4:00–4:30. Give the Chemex a gentle swirl to level the bed, then discard the filter and serve.',
+                pour: null
+            }
+        ];
+    }
+
+    function $(sel, root) {
+        return (root || document).querySelector(sel);
+    }
+
+    function $all(sel, root) {
+        return Array.prototype.slice.call((root || document).querySelectorAll(sel));
+    }
+
+    function openModal() {
+        $('.chemex-brew-overlay').classList.add('is-open');
+        showStage('setup');
+    }
+
+    function closeModal() {
+        clearAllTimers();
+        $('.chemex-brew-overlay').classList.remove('is-open');
+        state.stepIndex = 0;
+    }
+
+    function showStage(name) {
+        $all('.chemex-brew-stage').forEach(function (el) {
+            el.classList.remove('is-active');
+        });
+        $('.chemex-brew-stage[data-stage="' + name + '"]').classList.add('is-active');
+    }
+
+    function clearAllTimers() {
+        if (state.universalInterval) {
+            clearInterval(state.universalInterval);
+            state.universalInterval = null;
+        }
+        if (state.stepInterval) {
+            clearInterval(state.stepInterval);
+            state.stepInterval = null;
+        }
+        state.universalStart = null;
+        state.stepEndsAt = null;
+    }
+
+    function startUniversalTimer() {
+        state.universalStart = Date.now();
+        var el = $('.chemex-timer-universal .chemex-timer-value');
+        el.textContent = '00:00';
+        state.universalInterval = setInterval(function () {
+            var elapsed = Date.now() - state.universalStart;
+            el.textContent = formatTime(elapsed);
+        }, 250);
+    }
+
+    function startStepTimer(seconds) {
+        if (state.stepInterval) clearInterval(state.stepInterval);
+        state.stepEndsAt = Date.now() + seconds * 1000;
+        var el = $('.chemex-timer-step .chemex-timer-value');
+        el.textContent = formatTime(seconds * 1000);
+        state.stepInterval = setInterval(function () {
+            var remaining = state.stepEndsAt - Date.now();
+            if (remaining <= 0) {
+                remaining = 0;
+                clearInterval(state.stepInterval);
+                state.stepInterval = null;
+                onStepTimerEnd();
+            }
+            el.textContent = formatTime(remaining);
+        }, 250);
+    }
+
+    function onStepTimerEnd() {
+        ding();
+        var nextBtn = $('.chemex-next');
+        nextBtn.classList.add('chemex-btn');
+        nextBtn.textContent = state.stepIndex === state.steps.length - 1 ? 'Finish' : 'Next step';
+
+        if (state.autoAdvance) {
+            setTimeout(function () {
+                advanceStep();
+            }, 800);
+        }
+    }
+
+    function ding() {
+        try {
+            var ctx = new (window.AudioContext || window.webkitAudioContext)();
+            var o = ctx.createOscillator();
+            var g = ctx.createGain();
+            o.connect(g);
+            g.connect(ctx.destination);
+            o.type = 'sine';
+            o.frequency.value = 880;
+            g.gain.setValueAtTime(0.0001, ctx.currentTime);
+            g.gain.exponentialRampToValueAtTime(0.25, ctx.currentTime + 0.02);
+            g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.6);
+            o.start();
+            o.stop(ctx.currentTime + 0.65);
+        } catch (e) {
+            // Audio context not available — silently skip
+        }
+    }
+
+    function renderProgress() {
+        var container = $('.chemex-progress');
+        container.innerHTML = '';
+        state.steps.forEach(function (_, i) {
+            var dot = document.createElement('div');
+            dot.className = 'chemex-progress-dot';
+            if (i < state.stepIndex) dot.classList.add('is-done');
+            if (i === state.stepIndex) dot.classList.add('is-current');
+            container.appendChild(dot);
+        });
+    }
+
+    function renderStep() {
+        var step = state.steps[state.stepIndex];
+        $('.chemex-step-meta').textContent = 'Step ' + (state.stepIndex + 1) + ' of ' + state.steps.length + ' · ' + step.meta;
+        $('.chemex-step-title').textContent = step.title;
+        $('.chemex-step-desc').textContent = step.description;
+
+        var pourEl = $('.chemex-pour');
+        if (step.pour) {
+            pourEl.style.display = 'inline-block';
+            pourEl.textContent = step.pour;
+        } else {
+            pourEl.style.display = 'none';
+        }
+
+        $('.chemex-prev').disabled = state.stepIndex === 0;
+        var nextBtn = $('.chemex-next');
+        nextBtn.textContent = state.stepIndex === state.steps.length - 1 ? 'Finish' : 'Next step';
+
+        renderProgress();
+        startStepTimer(step.duration);
+    }
+
+    function advanceStep() {
+        if (state.stepIndex >= state.steps.length - 1) {
+            finishBrew();
+            return;
+        }
+        state.stepIndex++;
+        renderStep();
+    }
+
+    function goBack() {
+        if (state.stepIndex === 0) return;
+        state.stepIndex--;
+        renderStep();
+    }
+
+    function finishBrew() {
+        if (state.stepInterval) {
+            clearInterval(state.stepInterval);
+            state.stepInterval = null;
+        }
+        showStage('done');
+        var totalEl = $('.chemex-total-time');
+        var elapsed = state.universalStart ? Date.now() - state.universalStart : 0;
+        totalEl.textContent = formatTime(elapsed);
+        if (state.universalInterval) {
+            clearInterval(state.universalInterval);
+            state.universalInterval = null;
+        }
+    }
+
+    function startBrew() {
+        var cups = parseInt($('#chemex-cups').value, 10);
+        if (isNaN(cups) || cups < 1) cups = 1;
+        if (cups > 10) cups = 10;
+        state.cups = cups;
+
+        var recipe = buildRecipe(cups);
+        state.coffee = recipe.coffee;
+        state.water = recipe.water;
+        state.bloomWater = recipe.bloomWater;
+        state.pour1Water = recipe.pour1Water;
+        state.pour2Water = recipe.pour2Water;
+        state.steps = buildSteps(recipe);
+        state.stepIndex = 0;
+        state.autoAdvance = $('#chemex-auto-advance').checked;
+
+        showStage('brewing');
+        startUniversalTimer();
+        renderStep();
+    }
+
+    function updateRecipePreview() {
+        var cups = parseInt($('#chemex-cups').value, 10);
+        if (isNaN(cups) || cups < 1) cups = 1;
+        var recipe = buildRecipe(cups);
+        $('.chemex-recipe-coffee').textContent = recipe.coffee + 'g';
+        $('.chemex-recipe-water').textContent = recipe.water + 'ml';
+    }
+
+    function init() {
+        var trigger = $('.chemex-brew-trigger');
+        if (!trigger) return;
+
+        trigger.addEventListener('click', openModal);
+        $('.chemex-close').addEventListener('click', closeModal);
+        $('.chemex-brew-overlay').addEventListener('click', function (e) {
+            if (e.target === this) closeModal();
+        });
+
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && $('.chemex-brew-overlay').classList.contains('is-open')) {
+                closeModal();
+            }
+        });
+
+        $('#chemex-cups').addEventListener('input', updateRecipePreview);
+        $('.chemex-start').addEventListener('click', startBrew);
+        $('.chemex-next').addEventListener('click', advanceStep);
+        $('.chemex-prev').addEventListener('click', goBack);
+        $('.chemex-restart').addEventListener('click', function () {
+            clearAllTimers();
+            showStage('setup');
+        });
+
+        updateRecipePreview();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/public/wp-content/themes/chemex-club/src/scss/chemex-brew.scss
+++ b/public/wp-content/themes/chemex-club/src/scss/chemex-brew.scss
@@ -1,0 +1,324 @@
+@import "colors";
+
+.chemex-brew-trigger {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 1100;
+    padding: 12px 22px;
+    border: none;
+    border-radius: 30px;
+    background: $dark-brown;
+    color: $white;
+    font-family: 'Roboto', sans-serif;
+    font-size: 0.95em;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    box-shadow: 0 6px 18px rgba(87, 49, 16, 0.25);
+    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+
+    .fas {
+        margin-right: 8px;
+    }
+
+    &:hover {
+        background: $darkest-brown;
+        transform: translateY(-1px);
+        box-shadow: 0 10px 22px rgba(87, 49, 16, 0.3);
+    }
+
+    &:focus {
+        outline: none;
+    }
+}
+
+.chemex-brew-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 1200;
+    background: rgba(0, 0, 0, 0.6);
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    font-family: 'Roboto', sans-serif;
+
+    &.is-open {
+        display: flex;
+    }
+}
+
+.chemex-brew-modal {
+    background: #fff;
+    color: $black;
+    border-radius: 12px;
+    width: 100%;
+    max-width: 560px;
+    max-height: 90vh;
+    overflow-y: auto;
+    padding: 32px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    position: relative;
+
+    h2 {
+        font-family: 'EB Garamond', serif;
+        color: $darkest-brown;
+        margin: 0 0 8px;
+        font-size: 1.9em;
+    }
+
+    .chemex-subtitle {
+        color: $grey;
+        margin: 0 0 24px;
+        font-size: 0.95em;
+    }
+
+    .chemex-close {
+        position: absolute;
+        top: 14px;
+        right: 18px;
+        background: none;
+        border: none;
+        font-size: 1.6em;
+        color: $grey;
+        cursor: pointer;
+        line-height: 1;
+
+        &:hover {
+            color: $dark-brown;
+        }
+    }
+}
+
+.chemex-cups-input {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 20px 0 8px;
+
+    label {
+        font-weight: 600;
+        color: $darkest-brown;
+        margin: 0;
+    }
+
+    input[type="number"] {
+        width: 90px;
+        padding: 8px 12px;
+        font-size: 1em;
+        border: 2px solid $lightest-brown;
+        border-radius: 6px;
+        font-family: inherit;
+
+        &:focus {
+            outline: none;
+            border-color: $dark-brown;
+        }
+    }
+}
+
+.chemex-recipe {
+    background: $lightest-brown;
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin: 16px 0 24px;
+    font-size: 0.95em;
+    color: $darkest-brown;
+
+    span {
+        font-weight: 600;
+    }
+}
+
+.chemex-btn {
+    display: inline-block;
+    padding: 11px 22px;
+    border: none;
+    border-radius: 30px;
+    background: $dark-brown;
+    color: #fff;
+    font-family: inherit;
+    font-size: 0.95em;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease;
+
+    &:hover {
+        background: $darkest-brown;
+    }
+
+    &.chemex-btn-ghost {
+        background: transparent;
+        color: $dark-brown;
+        border: 2px solid $dark-brown;
+
+        &:hover {
+            background: $lightest-brown;
+        }
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+}
+
+.chemex-brew-stage {
+    display: none;
+
+    &.is-active {
+        display: block;
+    }
+}
+
+.chemex-timers {
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
+    margin: 8px 0 20px;
+
+    .chemex-timer {
+        flex: 1;
+        background: $lightest-brown;
+        border-radius: 8px;
+        padding: 14px;
+        text-align: center;
+
+        .chemex-timer-label {
+            font-size: 0.75em;
+            color: $darkest-brown;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-bottom: 6px;
+        }
+
+        .chemex-timer-value {
+            font-family: 'EB Garamond', serif;
+            font-size: 2em;
+            font-weight: 700;
+            color: $dark-brown;
+            line-height: 1;
+        }
+
+        &.chemex-timer-step .chemex-timer-value {
+            color: $darkest-brown;
+        }
+    }
+}
+
+.chemex-step-card {
+    background: #fff;
+    border: 2px solid $lightest-brown;
+    border-radius: 10px;
+    padding: 20px;
+    margin-bottom: 16px;
+
+    .chemex-step-meta {
+        font-size: 0.75em;
+        text-transform: uppercase;
+        letter-spacing: 1.5px;
+        color: $light-brown;
+        font-weight: 700;
+        margin-bottom: 6px;
+    }
+
+    h3 {
+        font-family: 'EB Garamond', serif;
+        color: $darkest-brown;
+        font-size: 1.5em;
+        margin: 0 0 10px;
+    }
+
+    p {
+        margin: 0 0 10px;
+        line-height: 1.5;
+    }
+
+    .chemex-pour {
+        background: $lightest-brown;
+        padding: 8px 12px;
+        border-radius: 6px;
+        font-weight: 600;
+        color: $darkest-brown;
+        display: inline-block;
+    }
+}
+
+.chemex-progress {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 20px;
+
+    .chemex-progress-dot {
+        flex: 1;
+        height: 6px;
+        border-radius: 3px;
+        background: $lightest-brown;
+        transition: background 0.2s ease;
+
+        &.is-done {
+            background: $dark-brown;
+        }
+
+        &.is-current {
+            background: $light-brown;
+        }
+    }
+}
+
+.chemex-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: space-between;
+    margin-top: 20px;
+
+    .chemex-actions-right {
+        display: flex;
+        gap: 10px;
+    }
+}
+
+.chemex-complete {
+    text-align: center;
+    padding: 20px 0;
+
+    .fas {
+        color: $dark-brown;
+        font-size: 3em;
+        margin-bottom: 12px;
+    }
+
+    h3 {
+        font-family: 'EB Garamond', serif;
+        color: $darkest-brown;
+        font-size: 1.8em;
+        margin: 0 0 8px;
+    }
+
+    p {
+        color: $darkest-brown;
+        margin: 0 0 20px;
+    }
+}
+
+@media (max-width: 600px) {
+    .chemex-brew-trigger {
+        top: 14px;
+        right: 14px;
+        padding: 10px 16px;
+        font-size: 0.85em;
+    }
+
+    .chemex-brew-modal {
+        padding: 24px 20px;
+
+        h2 {
+            font-size: 1.5em;
+        }
+    }
+
+    .chemex-timers .chemex-timer .chemex-timer-value {
+        font-size: 1.5em;
+    }
+}

--- a/public/wp-content/themes/chemex-club/src/scss/style.scss
+++ b/public/wp-content/themes/chemex-club/src/scss/style.scss
@@ -14,6 +14,7 @@
 
 @import "colors";
 @import "masonary";
+@import "chemex-brew";
 
 body{
 	color: $black;


### PR DESCRIPTION
## Summary
- Adds a floating **Brew Chemex** button in the top-right of every page (site-wide, loaded from `footer.php`).
- Clicking it opens a modal wizard: user picks **number of cups**, sees the computed coffee/water at a 1:17 pour-over ratio, then walks through six guided steps (rinse → grounds → bloom → first pour → final pour → drawdown).
- Two timers run simultaneously — a **universal total-brew timer** and a **per-step countdown** that chimes at zero and auto-advances (toggleable).

## Implementation
- `public/wp-content/themes/chemex-club/src/scss/chemex-brew.scss` — styles, uses existing theme color palette. Imported from `style.scss`.
- `public/wp-content/themes/chemex-club/src/js/chemex-brew.js` — wizard state, recipe calculation, timers. Gruntfile's `src/js/*.js` glob picks it up automatically and uglifies it into `main.js`.
- `public/wp-content/themes/chemex-club/chemex-brew.php` — button + modal markup. Included once from `footer.php` via `get_template_part()` so it's available on every page.
- No new dependencies, no new `wp_enqueue_*` calls needed — everything rides the existing `style.css` / `main.js` pipeline.

## Recipe defaults (per cup)
- 15g medium-coarse coffee
- 250ml water at 94–96°C
- Bloom = 2× coffee weight · wait 45s
- First main pour to ~55% remaining water · wait 45s
- Final pour to full target · drawdown ~90s
- Target total brew time: ~4:00–4:30

## Build
Run `grunt` in `public/wp-content/themes/chemex-club/` to produce `main.js` and `style.css` (both gitignored, same as existing flow).

## Test plan
- [ ] Visit any page on the site — the floating **Brew Chemex** button renders in the top-right, above content.
- [ ] Click it → modal opens on the setup stage; cup input defaults to 2, recipe preview shows 30g / 500ml.
- [ ] Change cup count — recipe preview updates live.
- [ ] Click **Start brewing** → wizard moves to the brewing stage, universal timer starts ticking up, step 1 countdown starts ticking down.
- [ ] Step timer hits zero → audio chime plays, wizard auto-advances (when the toggle is on).
- [ ] Toggle auto-advance off → step timer hits zero, wizard waits for **Next step** click.
- [ ] Back button moves to previous step and resets its countdown.
- [ ] Finishing the last step moves to the done stage with total brew time displayed.
- [ ] **Brew another** resets the wizard to the setup stage.
- [ ] `Esc` key and overlay click both close the modal.
- [ ] Mobile (≤600px): button and modal resize correctly; timers stay readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)